### PR TITLE
Create: UC, DM - ExtractData, VerifyData

### DIFF
--- a/Documents/DM_UC-xx-ExtractData.md
+++ b/Documents/DM_UC-xx-ExtractData.md
@@ -1,0 +1,36 @@
+# Domain Model for UC-xx : ExtractData
+
+**1) Extracting the Responsibilities**
+
+| Responsibility Description                                   | Type | Concept Name   |
+| ------------------------------------------------------------ | ---- | -------------- |
+| UseCase, UseCase의 논리적 집합 혹은 전체 시스템과 관련된 작업을 조정하고 다른 concept에 위임한다. | D    | Controller     |
+| 사용자가 업로드한 사진 파일                                  | K    | Image          |
+| OCR 모듈에서 추출한 정보                                     | K    | UserData       |
+| OCR 모듈과 데이터를 주고받는 모듈                            | D    | OCR_Connection |
+| 사용자에게 올바른 추출인지 검증 여부를 입력받는 변수         | K    | UserInput      |
+| 사용자에게 올바른 추출인지 검증 여부를 입력받는 모듈         | D    | GetInput       |
+| 이미지에서 민감정보를 가리는 모듈                            | D    | ObscureImage   |
+| 이미지와 정보, 혹은 올바르지 않은 형식의 정보인 이유를 출력  | D    | Viewer         |
+
+**2) Extracting the Associations**
+
+| Concept pair | Association Description | Association Name |
+| ------------------ | ----------------------- | ---------------- |
+| Controller <-> Image | 이미지는 Controller가 관리한다. (이후 삭제해야하므로) | manages data |
+| Controller <-> OCR_Connection | OCR 모듈에 사진파일을 전달한다. | conveys data     |
+| OCR_Connection <-> UserData | 추출한 정보를 저장한다. | provides data |
+| Controller <-> ObscureImage | 이미지 수정을 명령한다. | requests data |
+| ObscureImage <-> Image | Image에서 민감정보를 가린다. | modifies data |
+| Controller <-> GetInput | 유저에게 검증 여부를 입력받는다. | requests data |
+| GetInput <-> UserInput | 유저가 입력한 검증 여부를 저장한다. | conveys data |
+| Controller <-> Viewer | 상황에 맞는 출력을 명령한다. | requests data |
+
+
+**3) Extracting the Attributes**
+
+| Concept        | Attributes    | Attribute Description                                        |
+| -------------- | ------------- | ------------------------------------------------------------ |
+| OCR_Connection | Verification  | 추출된 정보가 올바른 정보인지 여부 (UC-xx-VerifyData를 통해 얻어냄) |
+|                | InvalidReason | 올바르지 않은 이유                                           |
+| ObscureImage   | ObscuredImage | 민감 정보가 가려진 이미지                                    |

--- a/Documents/DM_UC-xx-VerifyData.md
+++ b/Documents/DM_UC-xx-VerifyData.md
@@ -1,0 +1,24 @@
+# Domain Model for UC-xx : VerifyData
+
+**1) Extracting the Responsibilities**
+
+| Responsibility Description                                   | Type | Concept Name  |
+| ------------------------------------------------------------ | ---- | ------------- |
+| UseCase, UseCase의 논리적 집합 혹은 전체 시스템과 관련된 작업을 조정하고 다른 concept에 위임한다. | D    | Controller    |
+| OCR 모듈에서 추출한 정보                                     | K    | UserData      |
+| 올바른 형식으로 된 정보인지의 여부                           | K    | Verification  |
+| UserData를 검증하는 모듈                                     | D    | Verifier      |
+
+**2) Extracting the Associations**
+
+| Concept pair              | Association Description | Association Name |
+| ------------------------- | ----------------------- | ---------------- |
+| Controller <-> Verifier   | 정보 검증을 요청한다.   | requests data    |
+| Verifier <-> Verification | 검증 여부를 저장한다.   | conveys data     |
+| Verifier <-> UserData     | UserData를 검증한다.    | verifies data    |
+
+**3) Extracting the Attributes**
+
+| Concept      | Attributes    | Attribute Description                                        |
+| ------------ | ------------- | ------------------------------------------------------------ |
+| Verifier     | InvalidReason  | 올바르지 않은 이유 |

--- a/Documents/UC-xx-ExtractData.md
+++ b/Documents/UC-xx-ExtractData.md
@@ -1,0 +1,38 @@
+## Use Case UC-xx: ExtractData
+**1) Related Requirements** : REQ-4, REQ-5, REQ-6
+
+**2) Initiating Actors** : system(임시)  or 유저?
+
+**3) Actor's Goal** : 사진 파일에서 성명, 나이, 지역 정보를 읽어 추출한다.
+
+**4) Participating Actors** : OCR-module
+
+**5) Preconditions** :  
+
+**6) Postconditions** : 사진 파일은 삭제된다. 시스템에 추출한 정보를 전달한다.  
+
+**7) Flow of Events for Main Success Scenario**
+| Direction | n    | Actor Action                                                 |
+| --------- | ---- | ------------------------------------------------------------ |
+| →         | 1    | OCR module에 전달된 사진에서 정보를 추출한다.                |
+|           | 2    | include UC-xx-VerifyData                                     |
+| ←         | 3    | 추출된 정보를 민감 정보가 가려진 사진과 함께 띄워 유저에게 검증받는다. |
+| →         | 4    | 정보가 잘 추출되었는지 여부를 입력받는다.                    |
+| ←         | 5    | 시스템에 추출한 정보를 전달한다.                             |
+
+**8) Flow of Events for Extensions (Alternate Scenarios)**
+
+2a. 추출된 정보가 올바르지 않은 형식일 경우
+
+| Direction | n    | Actor Action                                        |
+| --------- | ---- | --------------------------------------------------- |
+| ←         | 1    | 추출된 정보가 올바르지 않은 형식인 이유를 출력한다. |
+| →         | 2    | 확인 버튼이 입력된다.                               |
+|           | 3    | include UC-01-Upload                                |
+
+
+
+4a. 추출된 정보가 올바르지 않다고 유저가 입력했을 경우
+| Direction | n    | Actor Action         |
+| --------- | ---- | -------------------- |
+|           | 1    | include UC-01-Upload |

--- a/Documents/UC-xx-VerifyData.md
+++ b/Documents/UC-xx-VerifyData.md
@@ -1,0 +1,26 @@
+## Use Case UC-xx: VerifyData
+**1) Related Requirements** : REQ-7, REQ-8, REQ-9
+
+**2) Initiating Actors** : OCR-Module
+
+**3) Actor's Goal** : 추출한 정보가 올바른 형식인지 검증한다.
+
+**4) Participating Actors** : 
+
+**5) Preconditions** :  OCR-Module에서 사진 파일을 읽어 정보가 추출된 상태여야 한다.
+
+**6) Postconditions** :  
+
+**7) Flow of Events for Main Success Scenario**
+| Direction | n    | Actor Action                          |
+| --------- | ---- | ------------------------------------- |
+| →         | 1    | 추출된 정보를 검증한다.               |
+| ←         | 2    | 추출된 정보가 올바른 형식임을 알린다. |
+
+**8) Flow of Events for Extensions (Alternate Scenarios)**
+
+1a. 추출된 정보가 올바르지 않은 형식일 경우
+
+| Direction | n    | Actor Action                                 |
+| --------- | ---- | -------------------------------------------- |
+| ←         | 1    | 추출한 정보가 올바르지 않은 이유를 전달한다. |


### PR DESCRIPTION
REQ-4~9를 cover하는 UC, DM에 대해 작성하였습니다.
일단 actor 설정이 조금 어려운데 user가 initiating actor로 있는 큰 UC를 하나 만들고 나머지는 작은 uc로 설계하여 include하는 방법도 있을 것 같으나 먼저 올려주신 문서에 최대한 부합하도록 작성해봤습니다.
REQ-5 사진파일 파기에 대해서는 처음에 사진파일을 입력받자마자 클라우드에 먼저 저장되는 방식이라면 따로 삭제하는 class를 설계해주어야 할 것 같습니다.

앞으로 다른 문서들도 최대한 유저 동작에 맞춰 작동하도록 작성하는 것이 생각하기 좋아 보입니다.